### PR TITLE
Fixing undefined folder when no XDG env vars

### DIFF
--- a/src/utils/find-log-path.ts
+++ b/src/utils/find-log-path.ts
@@ -4,9 +4,9 @@ export default function (appName = '') {
   let dir: string = '';
   switch (process.platform) {
     case 'linux':
-      dir = prepareDir(process.env['XDG_CONFIG_HOME'] + '', appName)
+      dir = prepareDir(process.env['XDG_CONFIG_HOME'], appName)
         .or(process.env['HOME'] + '/.config', appName)
-        .or(process.env['XDG_DATA_HOME'] + '', appName)
+        .or(process.env['XDG_DATA_HOME'], appName)
         .or(process.env['HOME'] + '/.local/share', appName).result;
       break;
     case 'darwin':


### PR DESCRIPTION
When the XDG_* env vars are undefined an undefined folder will be created on the users home.

This is because the path is defined with the sum of an undefined value plus and empty string '', this causes path to become the string "undefined" rather than the value undefined, provoking this undesired behavior.

Fixes #23 

## Proposed Changes

  - Remove the empty string concatenation so path is passes with the right value